### PR TITLE
Create ETHproductions-2.cjam

### DIFF
--- a/01-nest-nest-nest-stop/ETHproductions-2.cjam
+++ b/01-nest-nest-nest-stop/ETHproductions-2.cjam
@@ -1,0 +1,10 @@
+e# CJam > Japt, 4 languages, 11 bytes
+e# -5---10----5---20----5---30----5---40----5---50----5---60--64
+
+"'`STOP!'"p
+
+e# Full list of supported languages:
+e# CJam <http://cjam.aditsu.net> (1)
+e# Pyth <http://pyth.herokuapp.com> (2)
+e# GolfScript <http://golfscript.apphb.com> (3)
+e# Japt <http://ethproductions.github.io/japt> (4)

--- a/01-nest-nest-nest-stop/ETHproductions-2.cjam
+++ b/01-nest-nest-nest-stop/ETHproductions-2.cjam
@@ -1,10 +1,11 @@
-e# CJam > Japt, 4 languages, 11 bytes
+e# CJam > Jolf, 5 languages, 13 bytes
 e# -5---10----5---20----5---30----5---40----5---50----5---60--64
 
-"'`STOP!'"p
+"'Q+`STOP!'"p
 
 e# Full list of supported languages:
 e# CJam <http://cjam.aditsu.net> (1)
 e# Pyth <http://pyth.herokuapp.com> (2)
 e# GolfScript <http://golfscript.apphb.com> (3)
 e# Japt <http://ethproductions.github.io/japt> (4)
+e# Jolf <https://ethproductions.github.io/Jolf> (5) (Note: this is my fork of @ConorOBrien-Foxx's repo with a bug fix.)


### PR DESCRIPTION
Since no one seems to be writing super-golfy entries with super-golfy languages, I decided to do one myself. 5 languages in 13 bytes.

```
1. CJam:      "'Q+`STOP!'"p
2. Pyth:      "'Q+`STOP!'"
3. GolfScript: 'Q+`STOP!'
4. Japt:        Q+`STOP!
5. Jolf:          "STOP!
```

Note: Please use [my fork](https://ethproductions.github.io/Jolf) of @ConorOBrien-Foxx's Jolf repo, as his is currently unusable due to a bug.
